### PR TITLE
add Top link in masthead

### DIFF
--- a/_includes/masthead.html
+++ b/_includes/masthead.html
@@ -14,6 +14,9 @@
 
         
         <ul class="visible-links">
+          <li class="masthead__menu-item">
+            <a href="{{ '/' | relative_url }}">Top</a>
+          </li>
           {%- for link in site.data.navigation.main -%}
             {% if link.sublinks %}
               <li class="masthead__menu-item has-submenu">


### PR DESCRIPTION
## 変更点
- add Top link in masthead

<img width="1177" height="592" alt="image" src="https://github.com/user-attachments/assets/211f594c-f536-41b8-b3b4-9c6b5a40ee60" />
