### PR TITLE
Add three 2026 international conference entries (ACL / ICML)

### DIFF
--- a/collections/_internationalConferences/202607-acl-hara.md
+++ b/collections/_internationalConferences/202607-acl-hara.md
@@ -1,0 +1,15 @@
+---
+title: "Why Mean Pooling Works: Quantifying Second-Order Collapse in Text Embeddings"
+authors:
+  - Tomomasa Hara
+  - Hiroto Kurita
+  - Masaaki Imaizumi
+  - Kentaro Inui
+  - Sho Yokoi
+paper:
+  proceedings: "Proceedings of the 64th Annual Meeting of the Association for Computational Linguistics"
+  year_month: July 2026
+links:
+  - name: "arXiv"
+    url: "https://arxiv.org/abs/2604.27398"
+---

--- a/collections/_internationalConferences/202607-acl-yamamoto.md
+++ b/collections/_internationalConferences/202607-acl-yamamoto.md
@@ -1,0 +1,11 @@
+---
+title: "Timesteps of Mamba Align with Human Reading Times"
+authors:
+  - Yuji Yamamoto
+  - Shinnosuke Isono
+  - Yoshinobu Kawahara
+  - Sho Yokoi
+paper:
+  proceedings: "Findings of the Association for Computational Linguistics: ACL 2026"
+  year_month: July 2026
+---

--- a/collections/_internationalConferences/202607-icml-yoneda.md
+++ b/collections/_internationalConferences/202607-icml-yoneda.md
@@ -1,0 +1,19 @@
+---
+title: "SoftMatcha 2: A Fast and Soft Pattern Matcher for Trillion-Scale Corpora"
+authors:
+  - Masataka Yoneda
+  - Yusuke Matsushita
+  - Go Kamoda
+  - Kohei Suenaga
+  - Takuya Akiba
+  - Masaki Waga
+  - Sho Yokoi
+paper:
+  proceedings: "Forty-third International Conference on Machine Learning"
+  year_month: July 2026
+links:
+  - name: "Project Page"
+    url: "https://softmatcha.github.io/v2/"
+  - name: "arXiv"
+    url: "https://arxiv.org/abs/2602.10908"
+---


### PR DESCRIPTION
### Motivation
- Add new entries to the international conferences collection to index recently published 2026 ACL and ICML papers in the site. 
- Ensure metadata for these papers (title, authors, proceedings, year_month, and links where available) is available for rendering and discovery.

### Description
- Added `collections/_internationalConferences/202607-acl-hara.md` containing metadata for "Why Mean Pooling Works: Quantifying Second-Order Collapse in Text Embeddings" including authors and proceedings information. 
- Added `collections/_internationalConferences/202607-acl-yamamoto.md` containing metadata for "Timesteps of Mamba Align with Human Reading Times" including authors and proceedings information. 
- Added `collections/_internationalConferences/202607-icml-yoneda.md` containing metadata for "SoftMatcha 2: A Fast and Soft Pattern Matcher for Trillion-Scale Corpora" including authors, proceedings, and links to the project page and arXiv.

### Testing
- No automated tests were run for this content-only change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2a55001e7c832ebff4e4385afb0159)