### PR TITLE
update link and added redirect setting

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,3 +4,4 @@ gemspec
 gem "github-pages", group: :jekyll_plugins
 gem "jekyll-include-cache", group: :jekyll_plugins 
 gem "jekyll-paginate-v2", group: :jekyll_plugins
+gem 'jekyll-redirect-from', group: :jekyll_plugins

--- a/_config.yml
+++ b/_config.yml
@@ -261,6 +261,7 @@ plugins:
   - jekyll-gist
   - jekyll-feed
   - jekyll-include-cache
+  - jekyll-redirect-from
 
 # mimic GitHub Pages with --safe
 whitelist:
@@ -269,7 +270,7 @@ whitelist:
   - jekyll-gist
   - jekyll-feed
   - jekyll-include-cache
-
+  - jekyll-redirect-from
 
 # Archives
 #  Type

--- a/collections/_posts/2026-03-03-nlp2026-presentations.md
+++ b/collections/_posts/2026-03-03-nlp2026-presentations.md
@@ -3,6 +3,8 @@ layout: splash
 title: "言語処理学会第32回年次大会"
 category: News
 excerpt: "本研究室のメンバーが関わる8件の研究発表があります。"
+redirect_from:
+  - /posts/nlp2026-publications/
 header:
   show_overlay_excerpt: false
   show_date: true


### PR DESCRIPTION
## 変更点
- NLP2026の発表情報ニュースのURLを変更
- 変更前のものにアクセスしてもリダイレクトされるよう設定 (plugin追加)