### PR TITLE
[codex] Add ICML 2026 presentation info for Yoneda et al.

### DIFF
--- a/collections/_internationalConferences/202607-icml-yoneda.md
+++ b/collections/_internationalConferences/202607-icml-yoneda.md
@@ -11,6 +11,14 @@ authors:
 paper:
   proceedings: "Forty-third International Conference on Machine Learning"
   year_month: July 2026
+presentation:
+  conference:
+    name: "Forty-Third International Conference on Machine Learning"
+    abbreviation: "ICML 2026"
+    url: "https://icml.cc/Conferences/2026"
+  type: "Poster"
+  venue: "Seoul, South Korea"
+  year_month: July 2026
 links:
   - name: "Project Page"
     url: "https://softmatcha.github.io/v2/"


### PR DESCRIPTION
## What changed

Added presentation metadata to the SoftMatcha 2 / Yoneda et al. ICML 2026 publication entry:

- presentation type: Poster
- conference name, abbreviation, and official URL
- venue: Seoul, South Korea
- date: July 2026

## Why

The publication entry already contained the paper metadata but was missing the corresponding presentation information used by the website template.

## Validation

Checked the updated YAML structure against the existing ICLR 2025 presentation entry and verified the rendered fields expected by `_includes/pub-international-conf.html`. Conference details were verified against the official ICML 2026 website and the SoftMatcha 2 project page.