### PR TITLE
[codex] NLP 2026の書誌情報を追加

### DIFF
--- a/collections/_domesticConferences/202603-nlp-hara.md
+++ b/collections/_domesticConferences/202603-nlp-hara.md
@@ -6,6 +6,10 @@ authors:
   - 今泉允聡
   - 乾健太郎
   - 横井祥
+paper:
+  proceedings: "言語処理学会 第32回年次大会 発表論文集"
+  year_month: 2026年3月
+  pages: 2753-2758
 presentation:
   - type: "ポスター発表"
     venue: "宇都宮"
@@ -23,4 +27,3 @@ links:
   - name: "委員特別賞"
     url: "https://anlp.jp/nlp2026/award.html"
 ---
-

--- a/collections/_domesticConferences/202603-nlp-ishimine.md
+++ b/collections/_domesticConferences/202603-nlp-ishimine.md
@@ -4,6 +4,10 @@ authors:
   - 石峯拓海
   - 日野英逸
   - 横井祥
+paper:
+  proceedings: "言語処理学会 第32回年次大会 発表論文集"
+  year_month: 2026年3月
+  pages: 2726-2730
 presentation:
   - type: "ポスター発表"
     venue: "宇都宮"

--- a/collections/_domesticConferences/202603-nlp-kiya.md
+++ b/collections/_domesticConferences/202603-nlp-kiya.md
@@ -10,6 +10,10 @@ authors:
   - 塩野大輝
   - 坂口慶祐
   - 小林悟郎
+paper:
+  proceedings: "言語処理学会 第32回年次大会 発表論文集"
+  year_month: 2026年3月
+  pages: 2579-2584
 presentation:
   - type: "口頭発表"
     conference:

--- a/collections/_domesticConferences/202603-nlp-lee.md
+++ b/collections/_domesticConferences/202603-nlp-lee.md
@@ -3,7 +3,12 @@ title: "タスク算術の誤差項とその解釈"
 authors:
   - 李宰成
   - 中石海
+  - 鈴木潤
   - 横井祥
+paper:
+  proceedings: "言語処理学会 第32回年次大会 発表論文集"
+  year_month: 2026年3月
+  pages: 2609-2614
 presentation:
   - type: "ポスター発表"
     venue: "宇都宮"

--- a/collections/_domesticConferences/202603-nlp-ohashi.md
+++ b/collections/_domesticConferences/202603-nlp-ohashi.md
@@ -10,6 +10,10 @@ authors:
   - 塩野大輝
   - 坂口慶祐
   - 小林悟郎
+paper:
+  proceedings: "言語処理学会 第32回年次大会 発表論文集"
+  year_month: 2026年3月
+  pages: 2591-2596
 presentation:
   - type: "口頭発表"
     conference:

--- a/collections/_domesticConferences/202603-nlp-sakata.md
+++ b/collections/_domesticConferences/202603-nlp-sakata.md
@@ -6,6 +6,10 @@ authors:
   - 伊藤拓海
   - 横井祥
   - 乾健太郎
+paper:
+  proceedings: "言語処理学会 第32回年次大会 発表論文集"
+  year_month: 2026年3月
+  pages: 2597-2602
 presentation:
   - type: "ポスター発表"
     venue: "宇都宮"

--- a/collections/_domesticConferences/202603-nlp-yamamoto.md
+++ b/collections/_domesticConferences/202603-nlp-yamamoto.md
@@ -1,10 +1,14 @@
 ---
-title: 'Mambaの"処理時間"はヒトの読み時間と符号する'
+title: 'Mambaの"処理時間"はヒトの読み時間と符合する'
 authors:
   - 山本悠士
   - 磯野真之介
   - 河原吉伸
   - 横井祥
+paper:
+  proceedings: "言語処理学会 第32回年次大会 発表論文集"
+  year_month: 2026年3月
+  pages: 3410-3415
 presentation:
   - type: "ポスター発表"
     venue: "宇都宮"

--- a/collections/_domesticConferences/202603-nlp-yoneda.md
+++ b/collections/_domesticConferences/202603-nlp-yoneda.md
@@ -1,5 +1,5 @@
 ---
-title: "SoftMatcha 2: 一兆語規模のコーパスに対する柔らかく超高速な検索システム"
+title: "SoftMatcha 2: 1兆語規模コーパスの超高速かつ柔らかい検索"
 authors:
   - 米田優峻
   - 鴨田豪
@@ -8,6 +8,10 @@ authors:
   - 秋葉拓哉
   - 和賀正樹
   - 横井祥
+paper:
+  proceedings: "言語処理学会 第32回年次大会 発表論文集"
+  year_month: 2026年3月
+  pages: 375-380
 presentation:
   - type: "口頭発表"
     conference:


### PR DESCRIPTION
## 概要

Issue #39 に対応し、NLP 2026 の掲載論文8件へ予稿集名・開催年月・ページ範囲を追加しました。

## 変更内容

- NLP 2026 論文8件に公式予稿集のページ範囲を追加
- 「タスク算術の誤差項とその解釈」に抜けていた共著者（鈴木潤）を追加
- 公式予稿と異なっていた論文タイトル2件を修正
- 所属情報は現在のサイト形式では扱わないため追加していません

## 背景

登録時点では予稿集が未公開で、書誌情報が空欄になっていました。公開済みの言語処理学会第32回年次大会公式予稿集と照合して補完しています。

## 確認

- 対象8ファイルの YAML 読み込みを確認
- `git diff --check` 実行済み
- 公式プログラム、個別PDF、予稿集のページ範囲を照合
- ローカル環境では Jekyll の依存gemが未導入のため、フルビルドは未実施

Closes #39