### PR TITLE
[codex] Add Yamamoto ACL Anthology link

### DIFF
--- a/collections/_internationalConferences/202607-acl-hara.md
+++ b/collections/_internationalConferences/202607-acl-hara.md
@@ -7,7 +7,7 @@ authors:
   - Kentaro Inui
   - Sho Yokoi
 paper:
-  proceedings: "Proceedings of the 64th Annual Meeting of the Association for Computational Linguistics (Volume 1: Long Papers)"
+  proceedings: "Proceedings of the 64th Annual Meeting of the Association for Computational Linguistics"
   year_month: July 2026
   pages: 47180–47201
 presentation:

--- a/collections/_internationalConferences/202607-acl-hara.md
+++ b/collections/_internationalConferences/202607-acl-hara.md
@@ -7,17 +7,20 @@ authors:
   - Kentaro Inui
   - Sho Yokoi
 paper:
-  proceedings: "Proceedings of the 64th Annual Meeting of the Association for Computational Linguistics"
+  proceedings: "Proceedings of the 64th Annual Meeting of the Association for Computational Linguistics (Volume 1: Long Papers)"
   year_month: July 2026
+  pages: 47180–47201
 presentation:
   conference:
     name: "The 64th Annual Meeting of the Association for Computational Linguistics"
     abbreviation: "ACL 2026"
     url: "https://2026.aclweb.org/"
   type: "Poster"
-  venue: "California, United States"
+  venue: "San Diego, United States"
   year_month: July 2026
 links:
+  - name: "ACL Anthology"
+    url: "https://aclanthology.org/2026.acl-long.2183/"
   - name: "arXiv"
     url: "https://arxiv.org/abs/2604.27398"
 ---

--- a/collections/_internationalConferences/202607-acl-yamamoto.md
+++ b/collections/_internationalConferences/202607-acl-yamamoto.md
@@ -15,7 +15,7 @@ presentation:
     abbreviation: "ACL 2026"
     url: "https://2026.aclweb.org/"
   type: "Poster"
-  venue: "San Diego, California, United States"
+  venue: "San Diego, United States"
   year_month: July 2026
 links:
   - name: "ACL Anthology"

--- a/collections/_internationalConferences/202607-acl-yamamoto.md
+++ b/collections/_internationalConferences/202607-acl-yamamoto.md
@@ -16,4 +16,7 @@ presentation:
   type: "Poster"
   venue: "California, United States"
   year_month: July 2026
+links:
+  - name: "ACL Anthology"
+    url: "https://aclanthology.org/2026.findings-acl.1592/"
 ---

--- a/collections/_internationalConferences/202607-acl-yamamoto.md
+++ b/collections/_internationalConferences/202607-acl-yamamoto.md
@@ -8,13 +8,14 @@ authors:
 paper:
   proceedings: "Findings of the Association for Computational Linguistics: ACL 2026"
   year_month: July 2026
+  pages: 31820–31832
 presentation:
   conference:
     name: "The 64th Annual Meeting of the Association for Computational Linguistics"
     abbreviation: "ACL 2026"
     url: "https://2026.aclweb.org/"
   type: "Poster"
-  venue: "California, United States"
+  venue: "San Diego, California, United States"
   year_month: July 2026
 links:
   - name: "ACL Anthology"


### PR DESCRIPTION
## What changed

- Added the ACL Anthology link for “Timesteps of Mamba Align with Human Reading Times” to the publication entry.

## Why

The paper is now publicly available in the ACL Anthology, so the laboratory website can link readers to the official publication page.

## Impact

The ACL 2026 publication listing will display an “ACL Anthology” link for the paper.

## Validation

- Confirmed `https://aclanthology.org/2026.findings-acl.1592/` returns HTTP 200.
- Ran `git diff --check`.
- Ran `bundle exec jekyll build` successfully.